### PR TITLE
sync

### DIFF
--- a/board/safety/safety_gm.h
+++ b/board/safety/safety_gm.h
@@ -189,10 +189,10 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
       violation |= rt_rate_limit_check(desired_torque, rt_torque_last, GM_MAX_RT_DELTA);
 
       // every RT_INTERVAL set the new limits
-      uint32_t ts_elapsed = get_ts_elapsed(ts, ts_last);
+      uint32_t ts_elapsed = get_ts_elapsed(ts, ts_torque_check_last);
       if (ts_elapsed > GM_RT_INTERVAL) {
         rt_torque_last = desired_torque;
-        ts_last = ts;
+        ts_torque_check_last = ts;
       }
     }
 
@@ -205,7 +205,7 @@ static int gm_tx_hook(CANPacket_t *to_send, bool longitudinal_allowed) {
     if (violation || !current_controls_allowed) {
       desired_torque_last = 0;
       rt_torque_last = 0;
-      ts_last = ts;
+      ts_torque_check_last = ts;
     }
 
     if (violation) {

--- a/board/safety/safety_toyota.h
+++ b/board/safety/safety_toyota.h
@@ -6,6 +6,12 @@ const SteeringLimits TOYOTA_STEERING_LIMITS = {
   .max_rt_delta = 450,        // the real time limit is 1800/sec, a 20% buffer
   .max_rt_interval = 250000,
   .type = TorqueMotorLimited,
+
+  // the EPS faults when the steering angle rate is above a certain threshold for too long. to prevent this,
+  // we allow setting STEER_REQUEST bit to 0 while maintaining the requested torque value for a single frame
+  .min_valid_request_frames = 18,
+  .min_valid_request_rt_interval = 170000,  // 170ms; a ~10% buffer on cutting every 19 frames
+  .has_steer_req_tolerance = true,
 };
 
 // longitudinal limits

--- a/board/safety_declarations.h
+++ b/board/safety_declarations.h
@@ -46,6 +46,11 @@ typedef struct {
 
   // motor torque limits
   const int max_torque_error;
+
+  // safety around steer req bit
+  const int min_valid_request_frames;
+  const uint32_t min_valid_request_rt_interval;
+  const bool has_steer_req_tolerance;
 } SteeringLimits;
 
 typedef struct {
@@ -143,9 +148,11 @@ int cruise_button_prev = 0;
 // for safety modes with torque steering control
 int desired_torque_last = 0;       // last desired steer torque
 int rt_torque_last = 0;            // last desired torque for real time check
+int valid_steer_req_count = 0;     // counter for steer request bit matching non-zero torque
 struct sample_t torque_meas;       // last 6 motor torques produced by the eps
 struct sample_t torque_driver;     // last 6 driver torques measured
-uint32_t ts_last = 0;
+uint32_t ts_torque_check_last = 0;
+uint32_t ts_steer_req_mismatch_last = 0;  // last timestamp steer req was mismatched with torque
 
 // state for controls_allowed timeout logic
 bool heartbeat_engaged = false;             // openpilot enabled, passed in heartbeat USB command

--- a/tests/safety/test.c
+++ b/tests/safety/test.c
@@ -219,6 +219,8 @@ void init_tests(void){
   safety_mode_cnt = 2U;  // avoid ignoring relay_malfunction logic
   alternative_experience = 0;
   set_timer(0);
+  ts_steer_req_mismatch_last = 0;
+  valid_steer_req_count = 0;
 }
 
 void init_tests_honda(void){

--- a/tests/safety/test_toyota.py
+++ b/tests/safety/test_toyota.py
@@ -41,6 +41,8 @@ class TestToyotaSafety(common.PandaSafetyTest, common.InterceptorSafetyTest,
   MAX_RT_DELTA = 450
   RT_INTERVAL = 250000
   MAX_TORQUE_ERROR = 350
+  MIN_VALID_STEERING_FRAMES = 18
+  MIN_VALID_STEERING_RT_INTERVAL = 170000  # a ~10% buffer, can send steer up to 110Hz
   TORQUE_MEAS_TOLERANCE = 1  # toyota safety adds one to be conservative for rounding
   EPS_SCALE = 73
 


### PR DESCRIPTION
* toyota steer fault safety

* fix

* alternative safety

* no comment

* should be good

* same behavior, a bit simpler

* better tests

* fix comment

* update safety comment

* const is actual number of messages

* Fix bug

* misra

* Fix test

* clean up logic a bit

clean up logic a bit

fix

* fix

fix

* clean up tests

* unsigned

* forgot to rename message when merged

* Comments

Co-authored-by: Adeeb Shihadeh <adeebshihadeh@gmail.com>

* Update names

Co-authored-by: Adeeb Shihadeh <adeebshihadeh@gmail.com>

* rename rest of variables

* real time checks

* clean up safety tests

* revert

* add this

* clean up

* better name

* use common steering checks

* reverse order

* make common

* re-organize the safety

* clean up safety_toyota

* more clean up

* add comment back

* 19

* recover

* some variable name clean up

* rename and reset `valid_steering_msg_count`, another recover message

* move comment

* remove reset_toyota_timer, minor test clean up

* common test

* use init_tests

* threshold used to be: frame you can cut steer on, now it's min num of valid frames (next frame you can cut, 18+1)

* Update tests/safety/test_toyota.py

Co-authored-by: Adeeb Shihadeh <adeebshihadeh@gmail.com>

* fix realtime

* Update board/safety/safety_toyota.h

* Apply suggestions from code review

* Update board/safety/safety_toyota.h

Co-authored-by: Adeeb Shihadeh <adeebshihadeh@gmail.com>