### PR TITLE
Set mazda can mode to OBD_CAN2

### DIFF
--- a/board/main.c
+++ b/board/main.c
@@ -105,6 +105,15 @@ void set_safety_mode(uint16_t mode, uint16_t param) {
       }
       can_silent = ALL_CAN_LIVE;
       break;
+    case SAFETY_MAZDA
+      set_intercept_relay(true);
+      heartbeat_counter = 0U;
+      heartbeat_lost = false;
+      if (current_board->has_obd) {
+        current_board->set_can_mode(CAN_MODE_OBD_CAN2);
+      }
+      can_silent = ALL_CAN_LIVE;
+      break;
     default:
       set_intercept_relay(true);
       heartbeat_counter = 0U;


### PR DESCRIPTION
This lets us communicate with the TI, and does not affect non-TI users.